### PR TITLE
Merijn debugged reco level CP angle calculations

### DIFF
--- a/NTupleMaker/bin/SynchNTupleProducer_2017.cpp
+++ b/NTupleMaker/bin/SynchNTupleProducer_2017.cpp
@@ -68,15 +68,29 @@
 #define pionMass 		   0.1396
 
 
-
 void FillMuTau(const AC1B * analysisTree, Synch17Tree *otree, int leptonIndex, float dRiso);
 void FillETau(const AC1B * analysisTree, Synch17Tree *otree, int leptonIndex, float dRiso);
 void FillTau(const AC1B * analysisTree, Synch17Tree *otree, int tauIndex);
 void FillTau_leading(const AC1B * analysisTree, Synch17Tree *otree, int tauIndex);
 void initializeCPvar(Synch17Tree *otree);
+void SaveRECOVertices(const AC1B * analysisTree,Synch17Tree *otree, const bool isData);
 void initializeGenTree(Synch17GenTree *gentree);
 void FillGenTree(const AC1B * analysisTree, Synch17GenTree *gentree, TString ch);
 //void fillTTbarUncWeights(const AC1B * analysisTree, Synch17Tree *otree, bool isData, bool includeTTbarUncWeights);
+
+
+/*Notifications Merijn
+-to my experience currently macro only works for mu-tau (unless udpated in the meantime)
+-added a histogram and leafs in the otree to keep track of the pdg codes of the hadronically decaying tau, and ctr to keep track how often 2nd tau does NOT decay hadronically
+-we call an improved CP function, in which a number of bugs are solved. It takes the decay mode also as argument, to construct certain kinematic variables
+-Merijn suspects that second reco tau in mu-tau is currently not necessarily hadronically decaying, since RECO decay products substatial fraction 
+-see functionsCP.h for updates on the CP calculation
+*/
+
+
+//Merijn added a histogram to spot the pdg codes of the decaying hadronic tau
+TH1F* ConstitsPDG=new TH1F("ConstitsPDG","ConstitsPDG",500,-250,250);
+int nonpionphotonctr=0;
 
 int main(int argc, char * argv[]){
 
@@ -313,6 +327,10 @@ int main(int argc, char * argv[]){
   const float dxyLeptonCut     = cfg.get<float>("dxy"+lep+"Cut");
   const float dzLeptonCut      = cfg.get<float>("dz"+lep+"Cut");
 
+  cout<<"dxyLeptonCut "<<dxyLeptonCut<<endl;
+  cout<<"dzLeptonCut "<<dzLeptonCut<<endl;
+
+  
   const bool  applyLeptonId    = cfg.get<bool>("Apply"+lep+"Id");
 
   //dilepton veto
@@ -609,7 +627,7 @@ int main(int argc, char * argv[]){
 
     AC1B analysisTree(_tree, isData);
 
-    // set AC1B for JES systematics
+    // set AC1B for JES systematicsf_
     if (!isData && ApplySystShift && jetEnergyScaleSys.size() >0){
       for (unsigned int i=0; i<jetEnergyScaleSys.size(); i++)
 	(jetEnergyScaleSys.at(i))->SetAC1B(&analysisTree);
@@ -620,8 +638,8 @@ int main(int argc, char * argv[]){
     std::cout << "      number of entries in Tree = " << numberOfEntries << std::endl;
     ///////////////EVENT LOOP///////////////
     
-
-    for (Long64_t iEntry=0; iEntry<numberOfEntries; iEntry++) {       
+//for (Long64_t iEntry=0; iEntry<1000; iEntry++) {
+ for (Long64_t iEntry=0; iEntry<numberOfEntries; iEntry++) {       
       counter[0]++;
       analysisTree.GetEntry(iEntry);
       nEvents++;
@@ -633,6 +651,7 @@ int main(int argc, char * argv[]){
 	FillGenTree(&analysisTree,gentree,ch);
 	gentree->Fill();
       }
+
 
       //Skip events not passing the MET filters, if applied
       if (ApplyMetFilters && !passedAllMetFilters(&analysisTree, met_filters_list, isData)) continue;
@@ -675,7 +694,10 @@ int main(int argc, char * argv[]){
       otree->run  = analysisTree.event_run;
       otree->lumi = analysisTree.event_luminosityblock;
       otree->evt  = analysisTree.event_nr;
-	  
+     
+     //we fill vertices here;	
+     SaveRECOVertices(&analysisTree,otree, isData);
+		  
 
       bool overlapEvent = true;
       for (unsigned int iEvent=0; iEvent<runList.size(); ++iEvent) {
@@ -693,6 +715,7 @@ int main(int argc, char * argv[]){
       	continue;
 
       initializeGenTree(gentree);
+
        // weights
       if(ApplyPUweight) fill_weight(&analysisTree, otree, PUofficial, isData);
       
@@ -995,10 +1018,8 @@ int main(int argc, char * argv[]){
 	  for(unsigned int i_trig = 0; i_trig<filterDiTau.size(); i_trig++){
 	    if (nDiTauTrig.at(i_trig) == -1) continue;
 	    if (analysisTree.trigobject_filters[iT][nDiTauTrig.at(i_trig)]) isTauTrig = true;
-	  }
-	  
-	}
-	  
+	  }	  
+	}	  
       }
 	
       for(unsigned int i_trig = 0; i_trig<filterXtriggerTauLeg.size(); i_trig++)
@@ -1179,10 +1200,6 @@ int main(int argc, char * argv[]){
       jets::counting_jets(&analysisTree, otree, &cfg, &inputs_btag_scaling_medium);
       //MET
       fillMET(ch, leptonIndex, tauIndex, &analysisTree, otree);
-
-      //CP calculation
-      if(ch=="tt")acott(&analysisTree,otree,tauIndex,leptonIndex);
-
      
       TLorentzVector genV( 0., 0., 0., 0.);
       TLorentzVector genL( 0., 0., 0., 0.);
@@ -1414,7 +1431,36 @@ int main(int argc, char * argv[]){
 
       if (ApplySVFit && otree->njetspt20>0) svfit_variables(ch, &analysisTree, otree, &cfg, inputFile_visPtResolution);
 
-      otree->Fill();
+
+//addition Merijn: here we select the constituent of the tau with highest pT
+ int ncomponents = analysisTree.tau_constituents_count[tauIndex];
+  float maxPt=-1;
+  int sign = -1;
+  int pdgcode=-9999;
+  if(analysisTree.tau_charge[tauIndex]>0) sign = 1; 
+  for(int i=0;i<ncomponents;i++){  
+
+if((analysisTree.tau_constituents_pdgId[tauIndex][i]*sign)>0){
+
+      TLorentzVector lvector; lvector.SetXYZT(analysisTree.tau_constituents_px[tauIndex][i],
+					      analysisTree.tau_constituents_py[tauIndex][i],
+					      analysisTree.tau_constituents_pz[tauIndex][i],
+					      analysisTree.tau_constituents_e[tauIndex][i]);
+
+      double Pt = lvector.Pt();
+      if(Pt>maxPt){
+	pdgcode=analysisTree.tau_constituents_pdgId[tauIndex][i];
+	maxPt = Pt;
+	}
+    }
+  }
+
+ otree->pdgcodetau2=pdgcode; //Merijn tried here to assign to our tree. Not working yet so put in histogam..
+ ConstitsPDG->Fill(pdgcode);
+ if(abs(pdgcode)!=211&&abs(pdgcode)!=22) nonpionphotonctr++;
+// cout<<"nonpionphotonctr ="<<nonpionphotonctr<<endl;
+
+  otree->Fill();
 
 	  // evaluate systematics for MC 
       if(!isData && ApplySystShift){
@@ -1431,11 +1477,19 @@ int main(int argc, char * argv[]){
       }
       counter[19]++;
 
+
+  //CP calculation. Updates Merijn: placed calculation at end, when all kinematic corrections are performed. Removed statement to only do calculation for tt. Created the acott_Impr function, which takes ch as input as well. See the funcrtion in functionsCP.h to see my updates to the function itself
+
+      //if(ch=="tt")
+      acott_Impr(&analysisTree,otree,tauIndex,leptonIndex, ch);
+
+
       selEvents++;
       //std::cout << "*************SelEv " << selEvents << "************" << std::endl;
 
     } // end of file processing (loop over events in one file)
 
+ConstitsPDG->Write();
     nFiles++;
     delete _tree;
     file_->Close();
@@ -1451,8 +1505,11 @@ int main(int argc, char * argv[]){
   std::cout << "Total number of selected events = " << selEvents << std::endl;
   std::cout << std::endl;
   
+  cout<<"nonpionphotonctr ="<<nonpionphotonctr<<endl;
+
   file->cd("");
   file->Write();
+ConstitsPDG->Write();
 
   // delete systematics objects
 
@@ -1512,11 +1569,8 @@ int main(int argc, char * argv[]){
 
   file->Close();
   delete file;
-    
 
 }
-
-
 
 
 ////FILLING FUNCTIONS//////
@@ -1828,6 +1882,12 @@ void initializeGenTree(Synch17GenTree *gentree){
   gentree->acotautau_10 = -9999;
   gentree->acotautau_01 = -9999;
   gentree->acotautau_11 = -9999;
+
+  //init the new vertex variables to something nonsensible also
+  gentree->GenVertexX=-9999;
+  gentree->GenVertexY=-9999;
+  gentree->GenVertexZ=-99999;
+
 }
 
 void FillGenTree(const AC1B * analysisTree, Synch17GenTree *gentree, TString ch){
@@ -1914,6 +1974,46 @@ void FillGenTree(const AC1B * analysisTree, Synch17GenTree *gentree, TString ch)
   gentree->acotautau_11 = -9999;
   if (LeadingtauIndex>-1&&TrailingtauIndex>-1)
     gen_acott(analysisTree,gentree,LeadingtauIndex,TrailingtauIndex);
+
+
+//here fill the generator vertices to have the information present in tree
+
+  for (unsigned int igen=0; igen<analysisTree->genparticles_count; ++igen) {
+    if (analysisTree->genparticles_pdgid[igen]==23||analysisTree->genparticles_pdgid[igen]==24||
+	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36) {
+      gentree->GenVertexX=analysisTree->genparticles_vx[igen];
+      gentree->GenVertexY=analysisTree->genparticles_vy[igen];
+      gentree->GenVertexZ=analysisTree->genparticles_vz[igen];
+      break;
+    }
+  }
+
+
+}
+
+//add a dedicated function to fill the reco vertices. It is called after the 
+void SaveRECOVertices(const AC1B * analysisTree, Synch17Tree *otree, const bool isData){
+
+  otree->RecoVertexX=analysisTree->primvertex_x;
+  otree->RecoVertexY=analysisTree->primvertex_y;
+  otree->RecoVertexZ=analysisTree->primvertex_z;
+
+
+if(!isData){
+  for (unsigned int igen=0; igen<analysisTree->genparticles_count; ++igen) {
+    if (analysisTree->genparticles_pdgid[igen]==23||analysisTree->genparticles_pdgid[igen]==24||
+	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36) {
+      otree->GenVertexX=analysisTree->genparticles_vx[igen];
+      otree->GenVertexY=analysisTree->genparticles_vy[igen];
+      otree->GenVertexZ=analysisTree->genparticles_vz[igen];
+      break;
+    }
+  }
+}
+else{//if it is data, fill with something recognisable nonsensible
+      otree->GenVertexX=-9999;
+      otree->GenVertexY=-9999;
+      otree->GenVertexZ=-9999;}
 
 
 }

--- a/NTupleMaker/bin/SynchNTupleProducer_2017.cpp
+++ b/NTupleMaker/bin/SynchNTupleProducer_2017.cpp
@@ -508,6 +508,10 @@ int main(int argc, char * argv[]){
   TTree * tree = new TTree("TauCheck","TauCheck");
   TTree * gtree = new TTree("GenTauCheck","GenTauCheck");
 
+  //Merijn added a histogram to spot the pdg codes of the decaying hadronic tau
+  TH1F* ConstitsPDG=new TH1F("ConstitsPDG","ConstitsPDG",500,-250,250);
+  int nonpionphotonctr=0;
+
   Synch17Tree *otree = new Synch17Tree(tree);
   initializeCPvar(otree);
   Synch17GenTree *gentree = new Synch17GenTree(gtree);
@@ -1489,7 +1493,7 @@ if((analysisTree.tau_constituents_pdgId[tauIndex][i]*sign)>0){
 
     } // end of file processing (loop over events in one file)
 
-ConstitsPDG->Write();
+
     nFiles++;
     delete _tree;
     file_->Close();
@@ -1977,10 +1981,18 @@ void FillGenTree(const AC1B * analysisTree, Synch17GenTree *gentree, TString ch)
 
 
 //here fill the generator vertices to have the information present in tree
+//Note: we may want to add constraint that the W and Z are prompt. If we remove these, may get in trouble with a DY or W MC sample..
 
+/*
+bool isPrompt = true;
+	if (analysisTree.genparticles_info[index]==5||
+	    analysisTree.genparticles_info[index]==6) 
+isPrompt = false;
+
+*/
   for (unsigned int igen=0; igen<analysisTree->genparticles_count; ++igen) {
-    if (analysisTree->genparticles_pdgid[igen]==23||analysisTree->genparticles_pdgid[igen]==24||
-	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36) {
+    if ((analysisTree->genparticles_pdgid[igen]==23||analysisTree->genparticles_pdgid[igen]==24||
+	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36)&&analysisTree->genparticles_isLastCopy[igen]==1) {
       gentree->GenVertexX=analysisTree->genparticles_vx[igen];
       gentree->GenVertexY=analysisTree->genparticles_vy[igen];
       gentree->GenVertexZ=analysisTree->genparticles_vz[igen];
@@ -2001,8 +2013,20 @@ void SaveRECOVertices(const AC1B * analysisTree, Synch17Tree *otree, const bool 
 
 if(!isData){
   for (unsigned int igen=0; igen<analysisTree->genparticles_count; ++igen) {
-    if (analysisTree->genparticles_pdgid[igen]==23||analysisTree->genparticles_pdgid[igen]==24||
-	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36) {
+
+//here fill the generator vertices to have the information present in tree
+//Note: we may want to add constraint that the W and Z are prompt. If we remove these, may get in trouble with a DY or W MC sample..
+
+/*
+bool isPrompt = true;
+	if (analysisTree.genparticles_info[index]==5||
+	    analysisTree.genparticles_info[index]==6) 
+isPrompt = false;
+
+*/
+
+    if ((analysisTree->genparticles_pdgid[igen]==23||analysisTree->genparticles_pdgid[igen]==24||
+	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36)&&analysisTree->genparticles_isLastCopy[igen]==1) {
       otree->GenVertexX=analysisTree->genparticles_vx[igen];
       otree->GenVertexY=analysisTree->genparticles_vy[igen];
       otree->GenVertexZ=analysisTree->genparticles_vz[igen];

--- a/NTupleMaker/bin/SynchNTupleProducer_2017.cpp
+++ b/NTupleMaker/bin/SynchNTupleProducer_2017.cpp
@@ -1983,16 +1983,15 @@ void FillGenTree(const AC1B * analysisTree, Synch17GenTree *gentree, TString ch)
 //here fill the generator vertices to have the information present in tree
 //Note: we may want to add constraint that the W and Z are prompt. If we remove these, may get in trouble with a DY or W MC sample..
 
-/*
+
+  for (unsigned int igen=0; igen<analysisTree->genparticles_count; ++igen) {
+
 bool isPrompt = true;
-	if (analysisTree.genparticles_info[index]==5||
-	    analysisTree.genparticles_info[index]==6) 
+	if (analysisTree->genparticles_isPrompt) 
 isPrompt = false;
 
-*/
-  for (unsigned int igen=0; igen<analysisTree->genparticles_count; ++igen) {
     if ((analysisTree->genparticles_pdgid[igen]==23||analysisTree->genparticles_pdgid[igen]==24||
-	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36)&&analysisTree->genparticles_isLastCopy[igen]==1) {
+	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36)&&analysisTree->genparticles_isLastCopy[igen]==1&&isPrompt) {
       gentree->GenVertexX=analysisTree->genparticles_vx[igen];
       gentree->GenVertexY=analysisTree->genparticles_vy[igen];
       gentree->GenVertexZ=analysisTree->genparticles_vz[igen];
@@ -2014,19 +2013,18 @@ void SaveRECOVertices(const AC1B * analysisTree, Synch17Tree *otree, const bool 
 if(!isData){
   for (unsigned int igen=0; igen<analysisTree->genparticles_count; ++igen) {
 
-//here fill the generator vertices to have the information present in tree
+//here fill the generator vertices to have the gen information present in tree PER GOOD RECO EVENT
 //Note: we may want to add constraint that the W and Z are prompt. If we remove these, may get in trouble with a DY or W MC sample..
 
-/*
+
 bool isPrompt = true;
-	if (analysisTree.genparticles_info[index]==5||
-	    analysisTree.genparticles_info[index]==6) 
+	if (analysisTree->genparticles_isPrompt) 
 isPrompt = false;
 
-*/
+
 
     if ((analysisTree->genparticles_pdgid[igen]==23||analysisTree->genparticles_pdgid[igen]==24||
-	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36)&&analysisTree->genparticles_isLastCopy[igen]==1) {
+	analysisTree->genparticles_pdgid[igen]==25||analysisTree->genparticles_pdgid[igen]==35||analysisTree->genparticles_pdgid[igen]==36)&&analysisTree->genparticles_isLastCopy[igen]==1&&isPrompt) {
       otree->GenVertexX=analysisTree->genparticles_vx[igen];
       otree->GenVertexY=analysisTree->genparticles_vy[igen];
       otree->GenVertexZ=analysisTree->genparticles_vz[igen];

--- a/NTupleMaker/interface/Synch17GenTree.h
+++ b/NTupleMaker/interface/Synch17GenTree.h
@@ -3,6 +3,8 @@
 // Author: Andrea Cardini <andrea.cardini@desy.de>
 // 
 // Based on Spring15Tree by Francesco Costanza
+
+//Merijn added some changes <merijn.van.de.klundert@desy.de>
 //////////////////////////////////////////////////////////
 
 #ifndef Synch17GenTree_h
@@ -47,6 +49,11 @@ public :
   Float_t         acotautau_12;
   Float_t         acotautau_21;
   Float_t         acotautau_22;
+
+//gen vertex info is practical to have
+  Float_t GenVertexX;
+  Float_t GenVertexY;
+  Float_t GenVertexZ;
   
 
   //////////////////////////////////////////////
@@ -73,6 +80,11 @@ public :
   TBranch        *b_acotautau_12;
   TBranch        *b_acotautau_21;
   TBranch        *b_acotautau_22;
+
+//gen vertex info is practical to have
+  TBranch        *b_GenVertexX;
+  TBranch        *b_GenVertexY;
+  TBranch        *b_GenVertexZ;
 
   Synch17GenTree(TTree *tree=0);
   virtual ~Synch17GenTree();

--- a/NTupleMaker/interface/Synch17Tree.h
+++ b/NTupleMaker/interface/Synch17Tree.h
@@ -251,8 +251,17 @@ public :
   Float_t         acotautau_10;
   Float_t         acotautau_01;
   Float_t         acotautau_11;
-  
-  
+  Int_t		  pdgcodetau2;
+
+  //reco vertices
+  Float_t RecoVertexX;
+  Float_t RecoVertexY;
+  Float_t RecoVertexZ;
+
+  Float_t GenVertexX;
+  Float_t GenVertexY;
+  Float_t GenVertexZ;
+
 
   //////////////////////////////////////////////
   //            List of branches              //
@@ -486,7 +495,20 @@ public :
   TBranch        *b_acotautau_10;
   TBranch        *b_acotautau_01;
   TBranch        *b_acotautau_11;
-  
+  TBranch	 *b_pdgcodetau2;
+
+  //reco vertices
+  //RECO vertex info is practical to have
+
+  TBranch        *b_RecoVertexX;
+  TBranch        *b_RecoVertexY;
+  TBranch        *b_RecoVertexZ;  
+
+//gen vertex info is practical to have
+  TBranch        *b_GenVertexX;
+  TBranch        *b_GenVertexY;
+  TBranch        *b_GenVertexZ;
+
   Synch17Tree(TTree *tree=0);
   virtual ~Synch17Tree();
 

--- a/NTupleMaker/src/Synch17GenTree.cc
+++ b/NTupleMaker/src/Synch17GenTree.cc
@@ -3,6 +3,9 @@
 // Author: Andrea Cardini <andrea.cardini@desy.de>
 // 
 // Based on Spring15Tree by Francesco Costanza
+
+//Merijn van de Klundert <merijn.van.de.klundert@desy.de>
+
 //////////////////////////////////////////////////////////
 
 
@@ -78,6 +81,12 @@ void Synch17GenTree::ReadInit(TTree *tree)
    fChain->SetBranchAddress("acotautau_20", &acotautau_20, &b_acotautau_20);
    fChain->SetBranchAddress("acotautau_21", &acotautau_21, &b_acotautau_21);
    fChain->SetBranchAddress("acotautau_22", &acotautau_22, &b_acotautau_22);
+
+  //gen vertex info useful to have
+   fChain->SetBranchAddress("GenVertexX", &GenVertexX, &b_GenVertexX);
+   fChain->SetBranchAddress("GenVertexY", &GenVertexY, &b_GenVertexY);
+   fChain->SetBranchAddress("GenVertexZ", &GenVertexZ, &b_GenVertexZ);
+
    
    lock=true;
 }
@@ -175,6 +184,10 @@ void Synch17GenTree::WriteInit(TTree *tree) {
    fChain->Branch("acotautau_20", &acotautau_20, "acotautau_20/F");
    fChain->Branch("acotautau_21", &acotautau_21, "acotautau_21/F");
    fChain->Branch("acotautau_22", &acotautau_22, "acotautau_22/F");
+
+   fChain->Branch("GenVertexX", &GenVertexX, "GenVertexX/F");
+   fChain->Branch("GenVertexY", &GenVertexY, "GenVertexY/F");
+   fChain->Branch("GenVertexZ", &GenVertexZ, "GenVertexZ/F");
 
 }
 

--- a/NTupleMaker/src/Synch17Tree.cc
+++ b/NTupleMaker/src/Synch17Tree.cc
@@ -276,7 +276,18 @@ void Synch17Tree::ReadInit(TTree *tree)
    fChain->SetBranchAddress("acotautau_10", &acotautau_10, &b_acotautau_10);
    fChain->SetBranchAddress("acotautau_01", &acotautau_01, &b_acotautau_01);
    fChain->SetBranchAddress("acotautau_11", &acotautau_11, &b_acotautau_11);
-   
+   fChain->SetBranchAddress("pdgcodetau2", &pdgcodetau2, &b_pdgcodetau2);
+
+  //RECO vertex info useful to have
+   fChain->SetBranchAddress("RecoVertexX", &RecoVertexX, &b_RecoVertexX);
+   fChain->SetBranchAddress("RecoVertexY", &RecoVertexY, &b_RecoVertexY);
+   fChain->SetBranchAddress("RecoVertexZ", &RecoVertexZ, &b_RecoVertexZ);
+
+  //gen vertex info useful to have
+   fChain->SetBranchAddress("GenVertexX", &GenVertexX, &b_GenVertexX);
+   fChain->SetBranchAddress("GenVertexY", &GenVertexY, &b_GenVertexY);
+   fChain->SetBranchAddress("GenVertexZ", &GenVertexZ, &b_GenVertexZ);
+
    lock=true;
 }
 
@@ -571,6 +582,15 @@ void Synch17Tree::WriteInit(TTree *tree) {
    fChain->Branch("acotautau_10", &acotautau_10, "acotautau_10/F");
    fChain->Branch("acotautau_01", &acotautau_01, "acotautau_01/F");
    fChain->Branch("acotautau_11", &acotautau_11, "acotautau_11/F");
+   fChain->Branch("pdgcodetau2", &pdgcodetau2, "pdgcodetau2/F");
+
+   fChain->Branch("RecoVertexX", &RecoVertexX, "RecoVertexX/F");
+   fChain->Branch("RecoVertexY", &RecoVertexY, "RecoVertexY/F");
+   fChain->Branch("RecoVertexZ", &RecoVertexZ, "RecoVertexZ/F"); 
+
+   fChain->Branch("GenVertexX", &GenVertexX, "GenVertexX/F");
+   fChain->Branch("GenVertexY", &GenVertexY, "GenVertexY/F");
+   fChain->Branch("GenVertexZ", &GenVertexZ, "GenVertexZ/F");
 
 }
 

--- a/NTupleMaker/test/mutau/analysisMacroSynch_lept_mt_DYJetsToLL.conf
+++ b/NTupleMaker/test/mutau/analysisMacroSynch_lept_mt_DYJetsToLL.conf
@@ -2,7 +2,7 @@
 # configuration file for SynchMacro mt #
 ########################################
 isData = false
-JSON = DesyTauAnalyses/NTupleMaker/test/json/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt
+JSON = DesyTauAnalyses/NTupleMaker/test/json/Cert_294927-306462_13TeV_PromptReco_Collisions17_JSON.txt
 
 # flags
 ApplyMetFilters = false
@@ -34,6 +34,7 @@ idIsoEffFile_antiiso = HTT-utilities/LepEffInterface/data/Muon/Run2016BtoH/Muon_
 singleLepTrigEffFile_antiiso = HTT-utilities/LepEffInterface/data/Muon/Run2016BtoH/Muon_Mu22OR_eta2p1_antiisolated_Iso0p15to0p3_eff_rb.root
 xTrigLepLegEffFile_antiiso = HTT-utilities/LepEffInterface/data/Muon/Run2016BtoH/Muon_Mu19leg_eta2p1_antiisolated_Iso0p15to0p3_eff_rb.root
 
+TauIdSF = 0.89
 
 svFitPtResFile = TauAnalysis/SVfitStandalone/data/svFitVisMassAndPtResolutionPDF.root
 

--- a/NTupleMaker/test/mutau/run_mt.sh
+++ b/NTupleMaker/test/mutau/run_mt.sh
@@ -32,9 +32,9 @@
 #./condorsub_seq_leptau.sh SynchNTupleProducer_2017 analysisMacroSynch_lept_mt_DATA_SingleElectron.conf DATA_SingleElectron mt 20
 #./condorsub_seq_leptau.sh SynchNTupleProducer_2017 analysisMacroSynch_lept_mt_DATA_SingleMuon.conf DATA_SingleMuon mt 20
 
-./condorsub_seq_leptau.sh SynchNTupleProducer_2017 analysisMacroSynch_lept_mt_ggH125.conf ggH_125
+#./condorsub_seq_leptau.sh SynchNTupleProducer_2017 analysisMacroSynch_lept_mt_ggH125.conf ggH_125 mt 20
 #Merijn: here should be mt 20 or something. Also we could add the VBF here:
-#./condorsub_seq_leptau.sh SynchNTupleProducer_2017 analysisMacroSynch_lept_mt_VBF125.conf VBF_125 mt 20
+./condorsub_seq_leptau.sh SynchNTupleProducer_2017 analysisMacroSynch_lept_mt_VBF125.conf VBF_125 mt 20
 
 ./condorsub_seq_leptau.sh SynchNTupleProducer_2017 analysisMacroSynch_lept_mt_DATA_SingleMuon.conf DATA_MuB mt 20
 ./condorsub_seq_leptau.sh SynchNTupleProducer_2017 analysisMacroSynch_lept_mt_DATA_SingleMuon.conf DATA_MuC mt 20


### PR DESCRIPTION
This update focusses on the RECO level CP angle reconstruction for 1 prong (with/without pi^0).
Quite many things have been updated/debugged. Added code has been indicated with "merijn and a description" for clarity.

Updates:
-added histogram in SynchNTupleProducer_2017 to save pdg codes of highest pT decay product of the 2nd (expected hadronic) tau. It is in ~30% of cases a lepton instead..
-added vertex information on gen and reco level in Synch17GenTree and Synch17Tree
-added a new function acott_Impr function in functionsCP.h for the RECO cp angle calculations. It takes decay mode also as argument. Removed the constraint in macro of only excecuting it for "tt" option

-previously, the reco code used a lepton index as a tau index in calcpivec(), which gave random behavior. In the new calculation distinguish between the mu-tau, e-tau, or double-hadronic case. In leptonic case, added code to calculate lepton momenta (using also their rest mass for their energy), and obtain dx, dy, and dz from the big ntuple to calculate the impact parameter. for this added
ipVec_Lepton.
-added CP2 and CPCOUT for debugging purposes only..
-adapted initialisation of CP angles. Previously, some were uninitialised in certain circumstances
-adapted initialisation of calculation: if the second tau doesn't contain a pion, veto the calculation of the CP angles

There are a few things not yet understood and work in progress
---
Merijn
---