### PR TITLE
Higgs cp

### DIFF
--- a/NTupleMaker/interface/AC1B.h
+++ b/NTupleMaker/interface/AC1B.h
@@ -44,6 +44,18 @@ public :
    Float_t         primvertex_ptq;
    Int_t           primvertex_ntracks;
    Float_t         primvertex_cov[6];
+   
+   UInt_t          primvertexwithbs_count;
+   UInt_t          goodprimvertexwithbs_count;
+   Float_t         primvertexwithbs_x;
+   Float_t         primvertexwithbs_y;
+   Float_t         primvertexwithbs_z;
+   Float_t         primvertexwithbs_chi2;
+   Float_t         primvertexwithbs_ndof;
+   Float_t         primvertexwithbs_ptq;
+   Int_t           primvertexwithbs_ntracks;
+   Float_t         primvertexwithbs_cov[6];   
+   
    //Declaration of refitted vertices
    UInt_t          refitvertex_count;
    //UInt_t          goodrefitvertex_count;
@@ -54,7 +66,24 @@ public :
    Float_t         refitvertex_ndof[100];
    Float_t         refitvertex_ptq[100];
    Int_t           refitvertex_ntracks[100];
-   Float_t         refitvertex_cov[100][6];
+   //Float_t         refitvertex_cov[100][6];
+   Int_t   refitvertex_eleIndex[1000][2];
+   Int_t   refitvertex_muIndex[1000][2];
+   Int_t   refitvertex_tauIndex[1000][2];
+   
+   UInt_t          refitvertexwithbs_count;
+   Float_t         refitvertexwithbs_x[100];
+   Float_t         refitvertexwithbs_y[100];
+   Float_t         refitvertexwithbs_z[100];
+   Float_t         refitvertexwithbs_chi2[100];
+   Float_t         refitvertexwithbs_ndof[100];
+   Float_t         refitvertexwithbs_ptq[100];
+   Int_t           refitvertexwithbs_ntracks[100];
+   //Float_t         refitvertexwithbs_cov[100][6];
+   Int_t   refitvertexwithbs_eleIndex[1000][2];
+   Int_t   refitvertexwithbs_muIndex[1000][2];
+   Int_t   refitvertexwithbs_tauIndex[1000][2];
+   
    //...................................   
    UInt_t          muon_count;
    Float_t         muon_px[100];   //[muon_count]
@@ -756,6 +785,18 @@ public :
    TBranch        *b_primvertex_pdf;   //!
    TBranch        *b_primvertex_ntracks;   //!
    TBranch        *b_primvertex_cov;   //!
+   
+   TBranch        *b_primvertexwithbs_count;   //!
+   TBranch        *b_goodprimvertexwithbs_count;   //!
+   TBranch        *b_primvertexwithbs_x;   //!
+   TBranch        *b_primvertexwithbs_y;   //!
+   TBranch        *b_primvertexwithbs_z;   //!
+   TBranch        *b_primvertexwithbs_chi2;   //!
+   TBranch        *b_primvertexwithbs_ndof;   //!
+   TBranch        *b_primvertexwithbs_pdf;   //!
+   TBranch        *b_primvertexwithbs_ntracks;   //!
+   TBranch        *b_primvertexwithbs_cov;   //!
+   
    //refitvertix
    TBranch        *b_refitvertex_count;   //!
    TBranch        *b_refitvertex_x;   //!
@@ -765,7 +806,24 @@ public :
    TBranch        *b_refitvertex_ndof;   //!
    TBranch        *b_refitvertex_pdf;   //!
    TBranch        *b_refitvertex_ntracks;   //!
-   TBranch        *b_refitvertex_cov;   //!
+   //TBranch        *b_refitvertex_cov;   //!
+   TBranch        *b_refitvertex_eleIndex;
+   TBranch        *b_refitvertex_muIndex;
+   TBranch        *b_refitvertex_tauIndex;
+   
+   TBranch        *b_refitvertexwithbs_count;   //!
+   TBranch        *b_refitvertexwithbs_x;   //!
+   TBranch        *b_refitvertexwithbs_y;   //!
+   TBranch        *b_refitvertexwithbs_z;   //!
+   TBranch        *b_refitvertexwithbs_chi2;   //!
+   TBranch        *b_refitvertexwithbs_ndof;   //!
+   TBranch        *b_refitvertexwithbs_pdf;   //!
+   TBranch        *b_refitvertexwithbs_ntracks;   //!
+   //TBranch        *b_refitvertexwithbs_cov;   //!
+   TBranch        *b_refitvertexwithbs_eleIndex;
+   TBranch        *b_refitvertexwithbs_muIndex;
+   TBranch        *b_refitvertexwithbs_tauIndex;
+   
    TBranch        *b_muon_count;   //!
    TBranch        *b_muon_px;   //!
    TBranch        *b_muon_py;   //!
@@ -1555,6 +1613,18 @@ void AC1B::Init(TTree *tree, bool isData)
    fChain->SetBranchAddress("primvertex_ptq", &primvertex_ptq, &b_primvertex_pdf);
    fChain->SetBranchAddress("primvertex_ntracks", &primvertex_ntracks, &b_primvertex_ntracks);
    fChain->SetBranchAddress("primvertex_cov", primvertex_cov, &b_primvertex_cov);
+   
+   fChain->SetBranchAddress("primvertexwithbs_count", &primvertexwithbs_count, &b_primvertexwithbs_count);
+   fChain->SetBranchAddress("goodprimvertexwithbs_count", &goodprimvertexwithbs_count, &b_goodprimvertexwithbs_count);
+   fChain->SetBranchAddress("primvertexwithbs_x", &primvertexwithbs_x, &b_primvertexwithbs_x);
+   fChain->SetBranchAddress("primvertexwithbs_y", &primvertexwithbs_y, &b_primvertexwithbs_y);
+   fChain->SetBranchAddress("primvertexwithbs_z", &primvertexwithbs_z, &b_primvertexwithbs_z);
+   fChain->SetBranchAddress("primvertexwithbs_chi2", &primvertexwithbs_chi2, &b_primvertexwithbs_chi2);
+   fChain->SetBranchAddress("primvertexwithbs_ndof", &primvertexwithbs_ndof, &b_primvertexwithbs_ndof);
+   fChain->SetBranchAddress("primvertexwithbs_ptq", &primvertexwithbs_ptq, &b_primvertexwithbs_pdf);
+   fChain->SetBranchAddress("primvertexwithbs_ntracks", &primvertexwithbs_ntracks, &b_primvertexwithbs_ntracks);
+   fChain->SetBranchAddress("primvertexwithbs_cov", primvertexwithbs_cov, &b_primvertexwithbs_cov);
+   
    //refit vertices
    fChain->SetBranchAddress("refitvertex_count", &refitvertex_count, &b_refitvertex_count);
    //fChain->SetBranchAddress("goodrefitvertex_count", &goodrefitvertex_count, &b_goodrefitvertex_count);
@@ -1565,7 +1635,25 @@ void AC1B::Init(TTree *tree, bool isData)
    fChain->SetBranchAddress("refitvertex_ndof", refitvertex_ndof, &b_refitvertex_ndof);
    fChain->SetBranchAddress("refitvertex_ptq", refitvertex_ptq, &b_refitvertex_pdf);
    fChain->SetBranchAddress("refitvertex_ntracks",refitvertex_ntracks, &b_refitvertex_ntracks);
-   fChain->SetBranchAddress("refitvertex_cov",refitvertex_cov, &b_refitvertex_cov);
+   //fChain->SetBranchAddress("refitvertex_cov",refitvertex_cov, &b_refitvertex_cov);
+   fChain->SetBranchAddress("refitvertex_eleIndex", refitvertex_eleIndex, &b_refitvertex_eleIndex);
+   fChain->SetBranchAddress("refitvertex_muIndex", refitvertex_muIndex, &b_refitvertex_muIndex);
+   fChain->SetBranchAddress("refitvertex_tauIndex", refitvertex_tauIndex, &b_refitvertex_tauIndex);
+   
+   fChain->SetBranchAddress("refitvertexwithbs_count", &refitvertexwithbs_count, &b_refitvertexwithbs_count);
+   //fChain->SetBranchAddress("goodrefitvertex_count", &goodrefitvertex_count, &b_goodrefitvertex_count);
+   fChain->SetBranchAddress("refitvertexwithbs_x", refitvertexwithbs_x, &b_refitvertexwithbs_x);
+   fChain->SetBranchAddress("refitvertexwithbs_y", refitvertexwithbs_y, &b_refitvertexwithbs_y);
+   fChain->SetBranchAddress("refitvertexwithbs_z", refitvertexwithbs_z, &b_refitvertexwithbs_z);
+   fChain->SetBranchAddress("refitvertexwithbs_chi2", refitvertexwithbs_chi2, &b_refitvertexwithbs_chi2);
+   fChain->SetBranchAddress("refitvertexwithbs_ndof", refitvertexwithbs_ndof, &b_refitvertexwithbs_ndof);
+   fChain->SetBranchAddress("refitvertexwithbs_ptq", refitvertexwithbs_ptq, &b_refitvertexwithbs_pdf);
+   fChain->SetBranchAddress("refitvertexwithbs_ntracks",refitvertexwithbs_ntracks, &b_refitvertexwithbs_ntracks);
+   //fChain->SetBranchAddress("refitvertexwithbs_cov",refitvertexwithbs_cov, &b_refitvertexwithbs_cov);
+   fChain->SetBranchAddress("refitvertexwithbs_eleIndex", refitvertexwithbs_eleIndex, &b_refitvertexwithbs_eleIndex);
+   fChain->SetBranchAddress("refitvertexwithbs_muIndex", refitvertexwithbs_muIndex, &b_refitvertexwithbs_muIndex);
+   fChain->SetBranchAddress("refitvertexwithbs_tauIndex", refitvertexwithbs_tauIndex, &b_refitvertexwithbs_tauIndex);
+   
    fChain->SetBranchAddress("muon_count", &muon_count, &b_muon_count);
    fChain->SetBranchAddress("muon_px", muon_px, &b_muon_px);
    fChain->SetBranchAddress("muon_py", muon_py, &b_muon_py);

--- a/NTupleMaker/plugins/NTupleMaker.h
+++ b/NTupleMaker/plugins/NTupleMaker.h
@@ -333,6 +333,7 @@ class NTupleMaker : public edm::EDAnalyzer{
   bool crecprimvertex;
   bool crecprimvertexwithbs;
   bool crefittedvertex;
+  bool crefittedvertexwithbs;
   bool crecmuon;
   bool crecelectron;
   bool crectau;
@@ -461,6 +462,7 @@ class NTupleMaker : public edm::EDAnalyzer{
   edm::EDGetTokenT<VertexCollection> PVToken_;
   edm::EDGetTokenT<RefitVertexCollection> PVwithBSToken_;
   edm::EDGetTokenT<RefitVertexCollection>RefittedPVToken_;
+  edm::EDGetTokenT<RefitVertexCollection> RefittedwithBSPVToken_;
   edm::EDGetTokenT<LHEEventProduct> LHEToken_;
   edm::EDGetTokenT<double> SusyMotherMassToken_;
   edm::EDGetTokenT<double> SusyLSPMassToken_;
@@ -556,6 +558,20 @@ class NTupleMaker : public edm::EDAnalyzer{
   Int_t   refitvertex_eleIndex[M_refitvtxmaxcount][2];
   Int_t   refitvertex_muIndex[M_refitvtxmaxcount][2];
   Int_t   refitvertex_tauIndex[M_refitvtxmaxcount][2];
+	
+  // re-fitted vertex with bs
+  UInt_t  refitvertexwithbs_count;
+  Float_t refitvertexwithbs_x[M_refitvtxmaxcount];
+  Float_t refitvertexwithbs_y[M_refitvtxmaxcount];
+  Float_t refitvertexwithbs_z[M_refitvtxmaxcount];
+  Float_t refitvertexwithbs_chi2[M_refitvtxmaxcount];
+  Float_t refitvertexwithbs_ndof[M_refitvtxmaxcount];
+  Int_t   refitvertexwithbs_ntracks[M_refitvtxmaxcount];
+  Float_t refitvertexwithbs_cov[M_refitvtxmaxcount][6];
+  Float_t refitvertexwithbs_mindz[M_refitvtxmaxcount];
+  Int_t   refitvertexwithbs_eleIndex[M_refitvtxmaxcount][2];
+  Int_t   refitvertexwithbs_muIndex[M_refitvtxmaxcount][2];
+  Int_t   refitvertexwithbs_tauIndex[M_refitvtxmaxcount][2];
 
   // tracks
   UInt_t track_count;

--- a/NTupleMaker/test/wVertexRefit_TreeProducerFromMiniAOD_94x_MC.py
+++ b/NTupleMaker/test/wVertexRefit_TreeProducerFromMiniAOD_94x_MC.py
@@ -173,6 +173,8 @@ GenJets = cms.untracked.bool(not isData)
 process.load('VertexRefit.TauRefit.AdvancedRefitVertexProducer_cfi')
 process.AdvancedRefitVertexNoBSProducer.srcTaus = cms.InputTag("NewTauIDsEmbedded")
 process.AdvancedRefitVertexNoBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("slimmedElectrons"), cms.InputTag("slimmedMuons"), cms.InputTag("NewTauIDsEmbedded"))
+process.AdvancedRefitVertexBSProducer.srcTaus = cms.InputTag("NewTauIDsEmbedded")
+process.AdvancedRefitVertexBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("slimmedElectrons"), cms.InputTag("slimmedMuons"), cms.InputTag("NewTauIDsEmbedded"))
 process.load('VertexRefit.TauRefit.MiniAODRefitVertexProducer_cfi')
 
 process.makeroottree = cms.EDAnalyzer("NTupleMaker",
@@ -190,6 +192,7 @@ Trigger = cms.untracked.bool(True),
 RecPrimVertex = cms.untracked.bool(True),
 RecPrimVertexWithBS = cms.untracked.bool(True),
 RefittedVertex = cms.untracked.bool(False),
+RefittedVertexWithBS = cms.untracked.bool(True),
 RecBeamSpot = cms.untracked.bool(True),
 RecTrack = cms.untracked.bool(True),
 RecPFMet = cms.untracked.bool(True),
@@ -255,6 +258,7 @@ BeamSpotCollectionTag =  cms.InputTag("offlineBeamSpot"),
 PVCollectionTag = cms.InputTag("offlineSlimmedPrimaryVertices"),
 PVwithBSCollectionTag =  cms.InputTag("MiniAODRefitVertexBSProducer"),
 RefittedPVCollectionTag =  cms.InputTag("AdvancedRefitVertexNoBSProducer"),
+RefittedwithBSPVCollectionTag =  cms.InputTag("AdvancedRefitVertexBSProducer"),				      
 LHEEventProductTag = cms.InputTag("externalLHEProducer"),
 SusyMotherMassTag = cms.InputTag("susyInfo","SusyMotherMass"),
 SusyLSPMassTag = cms.InputTag("susyInfo","SusyLSPMass"),
@@ -519,6 +523,7 @@ process.p = cms.Path(
   #process.ApplyBaselineHBHENoiseFilter*  #reject events based 
   #process.ApplyBaselineHBHEISONoiseFilter*  #reject events based -- disable the module, performance is being investigated
   process.AdvancedRefitVertexNoBS *
+  process.AdvancedRefitVertexBS *	
   process.MiniAODRefitVertexBS*
   process.makeroottree
 )


### PR DESCRIPTION
Updated the higgs cp branch to store all four types of PV while producing bigntuples. Also made appropriate changes to AC1B.h which is used to read the bigntuples. The branches for storing refitted covariant matrices have been commented out since they are not needed anymore.